### PR TITLE
SSID für Freifunk Luxembourg hinzugefügt

### DIFF
--- a/app/src/main/assets/ssids.csv
+++ b/app/src/main/assets/ssids.csv
@@ -65,6 +65,7 @@
 "luebeck.freifunk.net (5GHz)"
 "lueneburg.freifunk.net"
 "lueneburg.freifunk.net (5GHz)"
+"luxembourg.freifunk.net"
 "Maxnet Mesh - Access Point"
 "muenchen.freifunk.net"
 "muenster.freifunk.net"


### PR DESCRIPTION
Freifunk Luxembourg fehlte
