### PR TITLE
Visible notification

### DIFF
--- a/app/src/main/java/com/example/tobiastrumm/freifunkautoconnect/NotificationService.java
+++ b/app/src/main/java/com/example/tobiastrumm/freifunkautoconnect/NotificationService.java
@@ -125,6 +125,7 @@ public class NotificationService extends Service {
                             .setSmallIcon(R.mipmap.ic_wifi_white_48dp)
                             .setContentTitle(getString(R.string.notification_title))
                             .setContentText(text)
+                            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
                             .setContentIntent(PendingIntent.getActivity(NotificationService.this,0, new Intent(Settings.ACTION_WIFI_SETTINGS),0));
 
             SharedPreferences prefMan = PreferenceManager.getDefaultSharedPreferences(NotificationService.this);


### PR DESCRIPTION
I added visibility public to the notification object so that the whole message is visible in the lock screen. This might be helpful as we don't display anything private or critical here
